### PR TITLE
feat: support kitty remote control along with tmux

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ LazyData: true
 Imports:
 Suggests: jsonlite
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/tmux.r
+++ b/R/tmux.r
@@ -1,21 +1,31 @@
-#' Get visidata command depedning on the TMUX settings
+#' Get visidata command
 #' @return visidata command as string
 get_vd_cmd <- function() {
-  tmux_cmd <- getOption("rvisidata.tmux")
 
-  if (Sys.getenv("TMUX", unset = "TMUX_IS_UNSET") == "TMUX_IS_UNSET")
-    return("vd")
+    default_cmd <- "vd"
+    cmd <- getOption("rvisidata.cmd")
 
-  # Check for null before checking value
-  # Null input clobbers logical returns (returns 0 length)
-  # Default to having tmux enabled
-  if (is.null(tmux_cmd))
-    return(system.file("tmux_pane.sh", package = "rvisidata"))
+    # If explicitly set to false, disable external cmd
+    if (!is.null(cmd) && cmd == FALSE) {
+        return(default_cmd)
+    }
 
-  # If explicitly set to false, disable tmux
-  if (tmux_cmd == FALSE)
-    return("vd")
+    # If explicitly set to "kitty" use the default kitty cmd
+    if (!is.null(cmd) && cmd == "kitty") {
+        return(system.file("kitty_window.sh", package = "rvisidata"))
+    }
 
-  # Users can choose their own script
-  return(tmux_cmd)
+    # If a custom cmd is set return that cmd
+    if (!is.null(cmd)) {
+        return(cmd)
+    }
+
+    # Check if we're working inside tmux; if positive, return the default tmux
+    # cmd
+    if (Sys.getenv("TMUX") != "") {
+        return(system.file("tmux_pane.sh", package = "rvisidata"))
+    }
+
+    # Return the default in case none of the above applies
+    return(default_cmd)
 }

--- a/README.md
+++ b/README.md
@@ -52,18 +52,24 @@ The default behaviour is to open `vd` in a vertical pane above the current pane,
 To disable this, set:
 
 ```r
-options(rvisidata.tmux = FALSE)
+options(rvisidata.cmd = FALSE)
+```
+
+If you're using the `kitty` terminal emulator (https://github.com/kovidgoyal/kitty), you can also open `vd` in a new tab within kitty, like this:
+
+```r
+options(rvisidata.cmd = "kitty")
 ```
 
 ### Advanced
 
-To customize the way `tmux` sets up this workspace (For example, opening `vd` in a new window rather than pane), you 
+To customize the way `tmux` or `kitty` set up this workspace (For example, opening `vd` in a new window rather than pane), you 
 may supply your own shell script that invokes `vd` on your dataset.
 
 Set:
 
 ```r
-options(rvisidata.tmux = "path/to/your/script")
+options(rvisidata.cmd = "path/to/your/script")
 ```
 
 Your script should take one argument, the filename to be opened.

--- a/inst/kitty_window.sh
+++ b/inst/kitty_window.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+filename=$1
+
+kitty @ launch --type=tab --tab-title "rvisidata" sh -c "vd $filename"

--- a/man/get_vd_cmd.Rd
+++ b/man/get_vd_cmd.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tmux.r
 \name{get_vd_cmd}
 \alias{get_vd_cmd}
-\title{Get visidata command depedning on the TMUX settings}
+\title{Get visidata command}
 \usage{
 get_vd_cmd()
 }
@@ -10,5 +10,5 @@ get_vd_cmd()
 visidata command as string
 }
 \description{
-Get visidata command depedning on the TMUX settings
+Get visidata command
 }


### PR DESCRIPTION
Hey there, thanks for this helpful package!
 
This is my attempt at adding support for the kitty (https://github.com/kovidgoyal/kitty) terminal emulator. I prefer kitty over tmux for being much more lightweight and less of a "hacky" solution (see kovidgoyal/kitty#2422)

Unfortunately, I couldn't find a way to "automagically" check if we're working inside a kitty instance, except for $TERMINAL or $TERMINFO environment variables which are, of course, set globally by the user irrespective of the current terminal effectively being used. If you have any suggestions on how to do this (or if the author of kitty will read this and have one), I'm happy to integrate it. However, with this PR, the user can set the "rvisidata.cmd" option to the string "kitty" to use the default cmd that I provided within the package, which opens visidata in a new tab. If you try to run a kitty remote cmd outside kitty, it simply goes on timeout after 10 secs, so we shouldn't worry too much about breaking things. 

I hope this is of interest to you and the users of the package, and I look forward to hearing your thoughts about this :)